### PR TITLE
Define test helper to remove duplication in LoggerTests with Nimble

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ DerivedData
 #
 # Pods/
 
+Carthage

--- a/Cartfile
+++ b/Cartfile
@@ -1,0 +1,1 @@
+github "Quick/Nimble" ~> 7.3.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,0 +1,1 @@
+github "Quick/Nimble" "v7.3.1"

--- a/FoodLogger.xcodeproj/project.pbxproj
+++ b/FoodLogger.xcodeproj/project.pbxproj
@@ -14,6 +14,8 @@
 		3FAF20352179DC4300701708 /* Food.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FAF20342179DC4300701708 /* Food.swift */; };
 		3FAF20372179DC8100701708 /* StorageMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FAF20362179DC8100701708 /* StorageMock.swift */; };
 		3FAF20392179DE0000701708 /* LoggerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FAF20382179DE0000701708 /* LoggerTests.swift */; };
+		3FAF203C2179DFA300701708 /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3FAF203B2179DFA300701708 /* Nimble.framework */; };
+		3FAF203E2179E00000701708 /* Nimble.framework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = 3FAF203B2179DFA300701708 /* Nimble.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -26,6 +28,20 @@
 		};
 /* End PBXContainerItemProxy section */
 
+/* Begin PBXCopyFilesBuildPhase section */
+		3FAF203D2179DFF400701708 /* Copy Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				3FAF203E2179E00000701708 /* Nimble.framework in Copy Frameworks */,
+			);
+			name = "Copy Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
 /* Begin PBXFileReference section */
 		3FAF20162179D25B00701708 /* FoodLogger.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = FoodLogger.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		3FAF20192179D25B00701708 /* FoodLogger.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FoodLogger.h; sourceTree = "<group>"; };
@@ -37,6 +53,7 @@
 		3FAF20342179DC4300701708 /* Food.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Food.swift; sourceTree = "<group>"; };
 		3FAF20362179DC8100701708 /* StorageMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageMock.swift; sourceTree = "<group>"; };
 		3FAF20382179DE0000701708 /* LoggerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggerTests.swift; sourceTree = "<group>"; };
+		3FAF203B2179DFA300701708 /* Nimble.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Nimble.framework; path = Carthage/Build/iOS/Nimble.framework; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -51,6 +68,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3FAF203C2179DFA300701708 /* Nimble.framework in Frameworks */,
 				3FAF20202179D25B00701708 /* FoodLogger.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -64,6 +82,7 @@
 				3FAF20182179D25B00701708 /* FoodLogger */,
 				3FAF20232179D25B00701708 /* FoodLoggerTests */,
 				3FAF20172179D25B00701708 /* Products */,
+				3FAF203A2179DFA200701708 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -96,6 +115,14 @@
 				3FAF20362179DC8100701708 /* StorageMock.swift */,
 			);
 			path = FoodLoggerTests;
+			sourceTree = "<group>";
+		};
+		3FAF203A2179DFA200701708 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				3FAF203B2179DFA300701708 /* Nimble.framework */,
+			);
+			name = Frameworks;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -137,6 +164,7 @@
 				3FAF201B2179D25B00701708 /* Sources */,
 				3FAF201C2179D25B00701708 /* Frameworks */,
 				3FAF201D2179D25B00701708 /* Resources */,
+				3FAF203D2179DFF400701708 /* Copy Frameworks */,
 			);
 			buildRules = (
 			);
@@ -413,6 +441,10 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+				);
 				INFOPLIST_FILE = FoodLoggerTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -433,6 +465,10 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+				);
 				INFOPLIST_FILE = FoodLoggerTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/FoodLoggerTests/LoggerTests.swift
+++ b/FoodLoggerTests/LoggerTests.swift
@@ -4,30 +4,23 @@ import XCTest
 
 class FoodLoggerTests: XCTestCase {
 
-    func testLoggerLogsMessageWithPasta() {
-        let storageMock = StorageMock()
-        let logger = Logger(storage: storageMock)
-
-        logger.log(Pasta())
-
-        expect(storageMock.hasStored("There's nothing like home made pasta")) == true
+    func testLoggerLog() {
+        expectLogger(logs: "There's nothing like home made pasta", forInput: Pasta())
+        expectLogger(logs: "Pizza is awesome!", forInput: Pizza())
+        expectLogger(logs: "I love gelato any time of the year", forInput: Gelato())
     }
 
-    func testLoggerLogsMessageWithPizza() {
+    private func expectLogger(
+        logs output: String,
+        forInput input: Any,
+        file: FileString = #file,
+        line: UInt = #line
+    ) {
         let storageMock = StorageMock()
         let logger = Logger(storage: storageMock)
 
-        logger.log(Pizza())
+        logger.log(input)
 
-        expect(storageMock.hasStored("Pizza is awesome!")) == true
-    }
-
-    func testLoggerLogsMessageWithGelato() {
-        let storageMock = StorageMock()
-        let logger = Logger(storage: storageMock)
-
-        logger.log(Gelato())
-
-        expect(storageMock.hasStored("I love gelato any time of the year")) == true
+        expect(storageMock.hasStored(output), file: file, line: line) == true
     }
 }

--- a/FoodLoggerTests/LoggerTests.swift
+++ b/FoodLoggerTests/LoggerTests.swift
@@ -1,4 +1,5 @@
 @testable import FoodLogger
+import Nimble
 import XCTest
 
 class FoodLoggerTests: XCTestCase {
@@ -9,7 +10,7 @@ class FoodLoggerTests: XCTestCase {
 
         logger.log(Pasta())
 
-        XCTAssert(storageMock.hasStored("There's nothing like home made pasta"))
+        expect(storageMock.hasStored("There's nothing like home made pasta")) == true
     }
 
     func testLoggerLogsMessageWithPizza() {
@@ -18,7 +19,7 @@ class FoodLoggerTests: XCTestCase {
 
         logger.log(Pizza())
 
-        XCTAssert(storageMock.hasStored("Pizza is awesome!"))
+        expect(storageMock.hasStored("Pizza is awesome!")) == true
     }
 
     func testLoggerLogsMessageWithGelato() {
@@ -27,6 +28,6 @@ class FoodLoggerTests: XCTestCase {
 
         logger.log(Gelato())
 
-        XCTAssert(storageMock.hasStored("I love gelato any time of the year"))
+        expect(storageMock.hasStored("I love gelato any time of the year")) == true
     }
 }


### PR DESCRIPTION
This is the same idea as #1, but done using [Nimble](https://githu.com/Quick/Nimble).

The full test for `Logger` can now be written as:

```swift
func testLoggerLogsMessageWithPasta() {
    expectLogger(logs: "There's nothing like home made pasta", forInput: Pasta())
    expectLogger(logs: "Pizza is awesome!", forInput: Pizza())
    expectLogger(logs: "I love gelato any time of the year", forInput: Gelato())
}
```

The cool thing is every new type-message pair can be tested with one extra line of code.