### PR TITLE
Inject logging transformation function in Logger

### DIFF
--- a/FoodLogger/Logger.swift
+++ b/FoodLogger/Logger.swift
@@ -1,21 +1,30 @@
 class Logger {
 
+    let transformation: (Any) -> String
     let storage: Storage
 
-    init(storage: Storage) {
+    init(
+        transformation: @escaping (Any) -> String = extractLogMessage(fromInput:),
+        storage: Storage
+    ) {
+        self.transformation = transformation
         self.storage = storage
     }
 
     func log(_ input: Any) {
-        switch input {
-        case is Gelato:
-            storage.persist("I love gelato any time of the year")
-        case is Pasta:
-            storage.persist("There's nothing like home made pasta")
-        case is Pizza:
-            storage.persist("Pizza is awesome!")
-        case _:
-            storage.persist("\(input)")
-        }
+        storage.persist(transformation(input))
+    }
+}
+
+func extractLogMessage(fromInput input: Any) -> String {
+    switch input {
+    case is Gelato:
+        return "I love gelato any time of the year"
+    case is Pasta:
+        return "There's nothing like home made pasta"
+    case is Pizza:
+        return "Pizza is awesome!"
+    case _:
+        return "\(input)"
     }
 }

--- a/FoodLoggerTests/LoggerTests.swift
+++ b/FoodLoggerTests/LoggerTests.swift
@@ -3,30 +3,30 @@ import XCTest
 
 class FoodLoggerTests: XCTestCase {
 
-    func testLoggerLogsMessageWithPasta() {
+    func testLoggerLogs() {
         let storageMock = StorageMock()
-        let logger = Logger(storage: storageMock)
+        let logger = Logger(
+            transformation: { _ in return "something" },
+            storage: storageMock
+        )
 
-        logger.log(Pasta())
+        logger.log("any input")
 
-        XCTAssert(storageMock.hasStored("There's nothing like home made pasta"))
+        XCTAssert(storageMock.hasStored("something"))
     }
 
-    func testLoggerLogsMessageWithPizza() {
-        let storageMock = StorageMock()
-        let logger = Logger(storage: storageMock)
-
-        logger.log(Pizza())
-
-        XCTAssert(storageMock.hasStored("Pizza is awesome!"))
-    }
-
-    func testLoggerLogsMessageWithGelato() {
-        let storageMock = StorageMock()
-        let logger = Logger(storage: storageMock)
-
-        logger.log(Gelato())
-
-        XCTAssert(storageMock.hasStored("I love gelato any time of the year"))
+    func testTransformation() {
+        XCTAssertEqual(
+            extractLogMessage(fromInput: Gelato()),
+            "I love gelato any time of the year"
+        )
+        XCTAssertEqual(
+            extractLogMessage(fromInput: Pasta()),
+            "There's nothing like home made pasta"
+        )
+        XCTAssertEqual(
+            extractLogMessage(fromInput: Pizza()),
+            "Pizza is awesome!"
+        )
     }
 }


### PR DESCRIPTION
This makes it easier to extend the Logger by extracting the logic to get from `Any` to a `String` message into a pure and standalone function.

It also makes it easier to test the component. We need only one test for the logging action now, and we can test the transformation function in isolation.