### PR TITLE
Make Logger expect a Loggable input

### DIFF
--- a/FoodLogger/Food.swift
+++ b/FoodLogger/Food.swift
@@ -1,5 +1,14 @@
-struct Pizza { }
+struct Pizza: Loggable {
 
-struct Gelato { }
+    let logMessage = "Pizza is awesome!"
+}
 
-struct Pasta { }
+struct Gelato: Loggable {
+
+    let logMessage = "I love gelato any time of the year"
+}
+
+struct Pasta: Loggable {
+
+    let logMessage = "There's nothing like home made pasta"
+}

--- a/FoodLogger/Logger.swift
+++ b/FoodLogger/Logger.swift
@@ -1,3 +1,7 @@
+protocol Loggable {
+    var logMessage: String { get }
+}
+
 class Logger {
 
     let storage: Storage
@@ -6,16 +10,7 @@ class Logger {
         self.storage = storage
     }
 
-    func log(_ input: Any) {
-        switch input {
-        case is Gelato:
-            storage.persist("I love gelato any time of the year")
-        case is Pasta:
-            storage.persist("There's nothing like home made pasta")
-        case is Pizza:
-            storage.persist("Pizza is awesome!")
-        case _:
-            storage.persist("\(input)")
-        }
+    func log(_ input: Loggable) {
+        storage.persist(input.logMessage)
     }
 }

--- a/FoodLoggerTests/FoodsLoggableTests.swift
+++ b/FoodLoggerTests/FoodsLoggableTests.swift
@@ -1,0 +1,17 @@
+@testable import FoodLogger
+import XCTest
+
+class FoodLoggableTests: XCTestCase {
+
+    func testGelatoLoggable() {
+        XCTAssertEqual(Gelato().logMessage, "I love gelato any time of the year"
+    }
+
+    func testPastaLoggable() {
+        XCTAssertEqual(Pasta().logMessage, "There's nothing like home made pasta"
+    }
+
+    func testPizzaLoggable() {
+        XCTAssertEqual(Pizza().logMessage, "Pizza is awesome!")
+    }
+}

--- a/FoodLoggerTests/LoggerTests.swift
+++ b/FoodLoggerTests/LoggerTests.swift
@@ -3,30 +3,18 @@ import XCTest
 
 class FoodLoggerTests: XCTestCase {
 
-    func testLoggerLogsMessageWithPasta() {
+    func testLoggerLogsMessage() {
         let storageMock = StorageMock()
+        let input = FakeLoggable()
         let logger = Logger(storage: storageMock)
 
-        logger.log(Pasta())
+        logger.log(input)
 
-        XCTAssert(storageMock.hasStored("There's nothing like home made pasta"))
+        XCTAssert(storageMock.hasStored(input.logMessage))
     }
+}
 
-    func testLoggerLogsMessageWithPizza() {
-        let storageMock = StorageMock()
-        let logger = Logger(storage: storageMock)
+struct FakeLoggable: Loggable {
 
-        logger.log(Pizza())
-
-        XCTAssert(storageMock.hasStored("Pizza is awesome!"))
-    }
-
-    func testLoggerLogsMessageWithGelato() {
-        let storageMock = StorageMock()
-        let logger = Logger(storage: storageMock)
-
-        logger.log(Gelato())
-
-        XCTAssert(storageMock.hasStored("I love gelato any time of the year"))
-    }
+    let logMessage = "log-message"
 }


### PR DESCRIPTION
This makes it easier to extend the `Logger`, as the thing required for a something to be logged is for it to conform to `Loggable`.

It also makes it easier to test the behaviour. Logger only needs one test, to ensure it uses its `Loggable` import properly.

Types conforming to `Loggable` can be tested in isolation, but it can be argued testing a static string is not very valuable. The only exception might be if you want to adda layer of safety to make sure changes to the static value are intentional. An unintentional test would break the tests.